### PR TITLE
Viewer: Deprecate pagination option

### DIFF
--- a/viewer/viewer/forms.py
+++ b/viewer/viewer/forms.py
@@ -13,13 +13,3 @@ class SearchForm(forms.Form):
             )
         ),
     )
-    paginate_by = forms.ChoiceField(
-        choices=(
-            (c, c)
-            for c in (
-                "50",
-                "100",
-                "200",
-            )
-        ),
-    )

--- a/viewer/viewer/static_src/crawsqueal.js
+++ b/viewer/viewer/static_src/crawsqueal.js
@@ -21,8 +21,6 @@ if ( form && filters ) {
   document.getElementById( 'update-button' ).classList.add( 'u-hidden' );
   form.addEventListener( 'submit', ev => {
     const searchType = filters.querySelector( 'input[name="search_type"]:checked' ).value || 'links';
-    const paginateBy = filters.querySelector( 'input[name="paginate_by"]:checked' ).value || '50';
     form.querySelector( 'input[name="search_type"]' ).value = searchType;
-    form.querySelector( 'input[name="paginate_by"]' ).value = paginateBy;
   });
 }

--- a/viewer/viewer/templates/viewer/page_list.html
+++ b/viewer/viewer/templates/viewer/page_list.html
@@ -76,7 +76,6 @@
             Go
           </button>
           <input type="hidden" name="search_type" value="{{ form.search_type }}">
-          <input type="hidden" name="paginate_by" value="{{ form.paginate_by }}">
           <input type="hidden" name="q" value="{{ form.q }}">
         </form>
   </nav>

--- a/viewer/viewer/templates/viewer/search_form.html
+++ b/viewer/viewer/templates/viewer/search_form.html
@@ -1,7 +1,6 @@
 <div class="search_wrapper u-mt30">
   <form action="{% url 'index' %}" id="search_form">
     <input type="hidden" name="search_type" value="{{ form.search_type | default:'links' }}">
-    <input type="hidden" name="paginate_by" value="{{ form.paginate_by | default:'50' }}">
     <h2 class="h4">Search terms</h2>
     <div class="o-form__input-w-btn">
       <div class="o-form__input-w-btn_input-container">

--- a/viewer/viewer/templates/viewer/search_side_bar.html
+++ b/viewer/viewer/templates/viewer/search_side_bar.html
@@ -21,23 +21,6 @@
           </fieldset>
         </div>
       </div>
-      <div class="o-form_group u-mb30">
-        <fieldset class="o-form_fieldset">
-          <legend class="h4">Results per page</legend>
-          <div class="m-form-field m-form-field__radio reg-radio">
-            <input class="a-radio" type="radio" value="50" id="results_50" name="paginate_by"{% if form.paginate_by is None or form.paginate_by == '50' %} checked{% endif %}>
-            <label class="a-label" for="results_50">50 per page</label>
-          </div>
-          <div class="m-form-field m-form-field__radio reg-radio">
-            <input class="a-radio" type="radio" value="100" id="results_100" name="paginate_by"{% if form.paginate_by == '100' %} checked{% endif %}>
-            <label class="a-label" for="results_100">100 per page</label>
-          </div>
-          <div class="m-form-field m-form-field__radio reg-radio">
-            <input class="a-radio" type="radio" value="200" id="results_200" name="paginate_by"{% if form.paginate_by == '200' %} checked{% endif %}>
-            <label class="a-label" for="results_200">200 per page</label>
-          </div>
-        </fieldset>
-      </div>
       <div class="o-form_group u-mb30" id="update-button">
         <fieldset class="o-form_fieldset u-mt20">
           <div class="input-with-btn_btn">

--- a/viewer/viewer/views.py
+++ b/viewer/viewer/views.py
@@ -15,10 +15,7 @@ from .models import Page
 class PageListView(ListView):
     model = Page
     context_object_name = "pages"
-    paginate_by = 50
-
-    def get_paginate_by(self, queryset):
-        return self.request.GET.get("paginate_by", self.paginate_by)
+    paginate_by = 25
 
     def get_context_data(self, *args, **kwargs):
         qs = self.object_list
@@ -28,12 +25,10 @@ class PageListView(ListView):
         if form.is_valid():
             q = form.cleaned_data.get("q")
             search_type = form.cleaned_data.get("search_type")
-            paginate_by = form.cleaned_data.get("paginate_by")
             pagination_query_params["q"] = q
 
             if q:
                 pagination_query_params["search_type"] = search_type
-                pagination_query_params["paginate_by"] = paginate_by
 
                 if "links" == search_type:
                     qs = qs.filter(links__icontains=q)


### PR DESCRIPTION
Per team discussion, this commit removes the "paginate_by" option from the viewer search form. Pagination is now fixed at 25 results per page, as suggested in the CFPB Design System:

https://cfpb.github.io/design-system/patterns/pagination

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/654645/173839279-99b02093-dee4-4aef-bb20-fcbec32377de.png">
