### PR TITLE
Fix two minor bugs related to wpull usage

### DIFF
--- a/crawler/management/commands/crawl.py
+++ b/crawler/management/commands/crawl.py
@@ -79,6 +79,4 @@ def command(start_url, db_filename, max_pages, depth, recreate, resume):
     # https://docs.djangoproject.com/en/3.2/topics/async/#async-safety
     os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
-    exit_status = app.run_sync()
-    click.echo(f"done, exiting with status {exit_status}")
-    return exit_status
+    app.run_sync()

--- a/crawler/management/commands/crawl.py
+++ b/crawler/management/commands/crawl.py
@@ -42,7 +42,7 @@ def command(start_url, db_filename, max_pages, depth, recreate, resume):
     )
 
     if not resume and os.path.exists(wpull_progress_filename):
-        os.path.remove(wpull_progress_filename)
+        os.remove(wpull_progress_filename)
 
     arg_parser = AppArgumentParser()
     args = arg_parser.parse_args(


### PR DESCRIPTION
1. Fix bug with overwriting wpull progress DB.
2. Don't base command exit code on wpull's exit code.
   Wpull's application class returns a non-zero exit code if there are any URL failures (for example DNS failure). We don't want our entire management command to return non-zero because of this.