### PR TITLE
Don't base command exit code on wpull's exit code

### DIFF
--- a/crawler/management/commands/crawl.py
+++ b/crawler/management/commands/crawl.py
@@ -79,4 +79,4 @@ def command(start_url, db_filename, max_pages, depth, recreate, resume):
     # https://docs.djangoproject.com/en/3.2/topics/async/#async-safety
     os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
-    app.run_sync()
+    return app.run_sync()


### PR DESCRIPTION
Currently the crawl management command always returns a zero exit code even if wpull has some kind of serious error. By default wpull returns a non-zero exit code for *any* failure, which is too sensitive - we don't want downstream processing to fail just because the crawler can't resolve the DNS of a link, for example.

This change reintroduces the wpull exit status codes but only for errors that don't relate to network failures (DNS, connectivity, etc).