### PR TITLE
Add support for RHEL8

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -14,7 +14,7 @@ from fabric import task
 
 DEPLOY_ROOT = "/opt"
 
-NODE_VERSION = "18"
+NODE_VERSION = "20"
 
 SQLITE_VERSION = "3390200"
 SQLITE_BASENAME = f"sqlite-autoconf-{SQLITE_VERSION}"

--- a/settings.py
+++ b/settings.py
@@ -7,6 +7,7 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
+
 import os
 import sys
 from pathlib import Path
@@ -160,3 +161,51 @@ LOGGING = {
         },
     },
 }
+
+# Monkey patch hashlib.md5 for FIPS mode compliance on RHEL8.
+# http://blog.serindu.com/2019/11/12/django-in-fips-mode/
+import hashlib
+import importlib
+
+
+def _non_security_md5(*args, **kwargs):
+    kwargs["usedforsecurity"] = False
+    return hashlib.md5(*args, **kwargs)
+
+
+def monkey_patch_md5(modules_to_patch):
+    """Monkey-patch calls to MD5 that aren't used for security purposes.
+
+    Sets RHEL's custom flag `usedforsecurity` to False allowing MD5 in FIPS mode.
+    `modules_to_patch` must be an iterable of module names (strings).
+    Modules must use `import hashlib` and not `from hashlib import md5`.
+    """
+    # Manually load a module as a unique instance
+    # https://stackoverflow.com/questions/11170949/how-to-make-a-copy-of-a-python-module-at-runtime
+    HASHLIB_SPEC = importlib.util.find_spec("hashlib")
+    patched_hashlib = importlib.util.module_from_spec(HASHLIB_SPEC)
+    HASHLIB_SPEC.loader.exec_module(patched_hashlib)
+
+    patched_hashlib.md5 = _non_security_md5  # Monkey patch MD5
+
+    # Inject our patched_hashlib for all requested modules
+    for module_name in modules_to_patch:
+        module = importlib.import_module(module_name)
+        module.hashlib = patched_hashlib
+
+
+modules_to_patch = [
+    "django.contrib.staticfiles.storage",
+    "django.core.cache.backends.filebased",
+    "django.core.cache.utils",
+    "django.db.backends.utils",
+    "django.db.backends.sqlite3.base",
+    "django.utils.cache",
+]
+
+try:
+    import hashlib
+
+    hashlib.md5()
+except ValueError:
+    monkey_patch_md5(modules_to_patch)


### PR DESCRIPTION
This change adds support for running this application on RHEL8.

The fabfile.py configuration and deployment scripts are simplified; RHEL8 includes Python 3.6 so we no longer need to install it, nor a different version of SQLite. We can also use Node 18 instead of Node 16.

The Python application code also needs to be modified to use a more secure version of hashlib.md5 to comply with FIPS mode. See http://blog.serindu.com/2019/11/12/django-in-fips-mode/ for background and the implemented workaround.

I've already tested this manually in our internal cloud environment; see internal CFGOV/crawler-deploy#2 for the associated CloudFormation template changes.