### PR TITLE
Update deploy configuration for RHEL8

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ _For information on how this project is deployed at the CFPB,
 employees and contractors should refer to the internal "CFGOV/crawler-deploy" repository._
 
 This repository includes a [Fabric](https://www.fabfile.org/) script
-that can be used to configure a RHEL7 Linux server to run this project
+that can be used to configure a RHEL8 Linux server to run this project
 and to deploy both the crawler and the viewer application to that server.
 
 To install Fabric in your virtual environment:
@@ -250,7 +250,7 @@ pip install -r requirements/deploy.txt
 
 ### Configuring a server
 
-To configure a remote RHEL7 server with the appropriate system requirements,
+To configure a remote RHEL8 server with the appropriate system requirements,
 you'll need to use some variation of this command:
 
 ```

--- a/fabfile.py
+++ b/fabfile.py
@@ -26,7 +26,7 @@ SOURCE_DIRNAME = "website-indexer"
 SOURCE_ROOT = f"{SOURCE_PARENT}/{SOURCE_DIRNAME}"
 
 CRAWL_DIR = "/var/tmp"
-CRAWL_DATABASE = f"{CRAWL_DIR}/crawl.sqlite3"
+CRAWL_DATABASE = f"{SOURCE_ROOT}/crawl.sqlite3"
 CRAWL_DATABASE_TMP = f"{CRAWL_DIR}/crawl-new.sqlite3"
 
 LOGROTATE_DIR = "/etc/logrotate.d"


### PR DESCRIPTION
This PR updates the repo fabfile.py for deploys to RHEL8. The only change has to do with the location of the crawl database file itself, moving it from /var/tmp to the deploy location in /opt/cfpb/website-indexer. This change is necesssary due to the different volume configuration in our RHEL8 AMI.

These changes have already been deployed manually to our internal crawler deployment, and are running successfully.