### PR TITLE
Don't crawl URLs on x.com

### DIFF
--- a/crawler/wpull_plugin.py
+++ b/crawler/wpull_plugin.py
@@ -27,6 +27,7 @@ SKIP_URLS = list(
         [
             r"^https://www.facebook.com/dialog/share\?.*",
             r"^https://twitter.com/intent/tweet\?.*",
+            r"^https://x.com/intent/tweet\?.*",
             r"^https://www.linkedin.com/shareArticle\?.*",
         ],
     )


### PR DESCRIPTION
The crawler logic currently skips links to twitter.com; as of https://github.com/cfpb/consumerfinance.gov/commit/846e03a1728bd568e3eefa4ef7ed1e3ccbcaeee1 the CFPB website now links to x.com instead. This change adds x.com to the crawl exclusion list.