### PR TITLE
Pagination fixup; Better Prettier handling of Jinja templates

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -71,7 +71,7 @@ const postCSSPlugin = ({ plugins = [], lessOptions = {} }) => ({
           math: "always",
           paths: [
             ...readdirSync(`${modules}/@cfpb`).map(
-              (v) => `${modules}/@cfpb/${v}/src`
+              (v) => `${modules}/@cfpb/${v}/src`,
             ),
             `${modules}`,
           ],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,22 @@
     "postcss-less": "^6.0.0"
   },
   "devDependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^3.3.3",
+    "prettier-plugin-jinja-template": "^1.4.1"
+  },
+  "prettier": {
+    "plugins": [
+      "prettier-plugin-jinja-template"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "*.html"
+        ],
+        "options": {
+          "parser": "jinja-template"
+        }
+      }
+    ]
   }
 }

--- a/viewer/static_src/css/skip-nav.less
+++ b/viewer/static_src/css/skip-nav.less
@@ -10,7 +10,9 @@
     width: 1px;
     overflow: hidden;
     background: transparent;
-    transition: transform 1s ease, background 0.5s linear;
+    transition:
+      transform 1s ease,
+      background 0.5s linear;
     z-index: 11;
 
     &:focus {
@@ -25,7 +27,9 @@
       width: auto;
       overflow: visible;
       outline: 0;
-      transition: transform 0.1s ease, background 0.2s linear;
+      transition:
+        transform 0.1s ease,
+        background 0.2s linear;
     }
 
     &--flush-left:focus {

--- a/viewer/static_src/js/main.js
+++ b/viewer/static_src/js/main.js
@@ -3,7 +3,7 @@ import { Expandable } from "@cfpb/cfpb-expandables";
 const docElement = document.documentElement;
 docElement.className = docElement.className.replace(
   /(^|\s)no-js(\s|$)/,
-  "$1$2"
+  "$1$2",
 );
 
 Expandable.init();

--- a/viewer/templates/viewer/base.html
+++ b/viewer/templates/viewer/base.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="no-js">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/viewer/templates/viewer/component_list.html
+++ b/viewer/templates/viewer/component_list.html
@@ -3,16 +3,8 @@
   {{ results | length | intcomma }} total
   <a class="a-link a-link__icon" href="https://cfpb.github.io/design-system">
     <span class="a-link__text">CFPB Design System</span>
-    <svg
-      class="cf-icon-svg"
-      viewBox="0 0 14 19"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M13.017 3.622v4.6a.554.554 0 0 1-1.108 0V4.96L9.747 7.122a1.65 1.65 0 0 1 .13.646v5.57A1.664 1.664 0 0 1 8.215 15h-5.57a1.664 1.664 0 0 1-1.662-1.663v-5.57a1.664 1.664 0 0 1 1.662-1.662h5.57A1.654 1.654 0 0 1 9 6.302l2.126-2.126H7.863a.554.554 0 1 1 0-1.108h4.6a.554.554 0 0 1 .554.554zM8.77 8.1l-2.844 2.844a.554.554 0 0 1-.784-.783l2.947-2.948H2.645a.555.555 0 0 0-.554.555v5.57a.555.555 0 0 0 .554.553h5.57a.555.555 0 0 0 .554-.554z"
-      ></path>
-    </svg>
-  </a>
+    {% include "external-link.svg" %}</a
+  >
   component{{ results | length | pluralize }}
 </div>
 

--- a/viewer/templates/viewer/component_list.html
+++ b/viewer/templates/viewer/component_list.html
@@ -1,24 +1,25 @@
-{% extends './base.html' %} {% load humanize %} {% block content %}
-<div class="lead-paragraph">
-  {{ results | length | intcomma }} total
-  <a class="a-link a-link__icon" href="https://cfpb.github.io/design-system">
-    <span class="a-link__text">CFPB Design System</span>
-    {% include "external-link.svg" %}</a
-  >
-  component{{ results | length | pluralize }}
-</div>
+{% extends './base.html' %} {% load humanize %}
+{% block content %}
+  <div class="lead-paragraph">
+    {{ results | length | intcomma }} total
+    <a class="a-link a-link__icon" href="https://cfpb.github.io/design-system">
+      <span class="a-link__text">CFPB Design System</span>
+      {% include "external-link.svg" %}</a
+    >
+    component{{ results | length | pluralize }}
+  </div>
 
-<div class="block block--flush-top">
-  <ul class="m-list">
-    {% for component in results %}
-    <li class="results_item">
-      <a
-        href="{% url 'index' %}?search_type=components&q={{ component.class_name | escape }}"
-      >
-        {{ component.class_name }}
-      </a>
-    </li>
-    {% endfor %}
-  </ul>
-</div>
+  <div class="block block--flush-top">
+    <ul class="m-list">
+      {% for component in results %}
+        <li class="results_item">
+          <a
+            href="{% url 'index' %}?search_type=components&q={{ component.class_name | escape }}"
+          >
+            {{ component.class_name }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
 {% endblock content %}

--- a/viewer/templates/viewer/help.html
+++ b/viewer/templates/viewer/help.html
@@ -1,211 +1,216 @@
 {% extends './base.html' %} {% load static %}
 
-<!-- prettier-ignore -->
 {% block breadcrumbs %}
-{% include "viewer/breadcrumbs.html" %}
+  {% include "viewer/breadcrumbs.html" %}
 {% endblock breadcrumbs %}
 
 {% block content %}
-<div class="block block--flush-top">
-  <h1>Common searches</h1>
+  <div class="block block--flush-top">
+    <h1>Common searches</h1>
 
-  <p>
-    This tool stores a nightly snapshot of consumerfinance.gov web page data
-    that you can search for all sorts of useful things. Common search examples
-    are below. You can also
-    <a href="#data-about">learn more about the data</a>.
-  </p>
-  <p>
-    View results in the browser, or export them as a CSV. For those less handy
-    with Excel, it may be useful to
-    <a
-      class="a-link a-link__icon"
-      href="{% static 'query-string-filtering.docx' %}"
-    >
-      <span class="a-link__text"
-        >learn how to filter out results with query strings</span
-      >
-      {% include "download.svg" %}.
-    </a>
-  </p>
-</div>
-
-<div class="block block--sub">
-  <h2>Title</h2>
-  <p>Find all instances of a string in the title of a cf.gov page.</p>
-  <h3>Examples</h3>
-  <ul class="m-list">
-    <li class="m-list__item">
-      You want a list of all pages with the word "Chopra" in the title.
-      <a href="{% url 'index' %}?search_type=title&q=Chopra">Search "Chopra"</a>
-    </li>
-  </ul>
-</div>
-
-<div class="block block--sub">
-  <h2>URL</h2>
-  <p>Find all instances of a string in the URL of a cf.gov page.</p>
-  <h3>Examples</h3>
-  <ul class="m-list">
-    <li class="m-list__item">
-      Your stakeholder wants a list of all the pages in a given site section.
-      <a
-        href="{% url 'index' %}?search_type=links&q={{ '/about-us/the-bureau/bureau-structure/' | urlencode }}"
-      >
-        Search "/about-us/the-bureau/bureau-structure/"
-      </a>
-    </li>
-  </ul>
-</div>
-
-<div class="block block--sub">
-  <h2>Components</h2>
-  <p>
-    Search by
-    <a href="{% url 'components' %}">class names</a>
-    of our
-    <a class="a-link a-link__icon" href="https://cfpb.github.io/design-system/">
-      <span class="a-link__text">Design System</span>
-      {% include "external-link.svg" %}</a
-    >components and patterns. Partial searches also work: searching for
-    "notification" will return pages containing "m-notification",
-    "m-notification__borderless", etc.
-  </p>
-  <h3>Examples</h3>
-  <ul class="m-list">
-    <li class="m-list__item">
-      You're doing an audit of all occurrences of the notification pattern.
-      <a href="{% url 'index' %}?search_type=components&q=m-notification">
-        Search "m-notification"
-      </a>
-    </li>
-  </ul>
-</div>
-
-<div class="block block--sub">
-  <h2>Links</h2>
-  <p>
-    Find all instances of a string in the URLs of links listed on a cf.gov page,
-    excluding the header and footer.
-  </p>
-  <h3>Examples</h3>
-  <ul class="m-list">
-    <li class="m-list__item">
-      You're looking for all instances of external links to the FTC.
-      <a href="{% url 'index' %}?search_type=links&q=FTC">Search "FTC"</a>
-    </li>
-    <li class="m-list__item">
-      You want to find and remediate accidental links to the content server.
-      <a
-        href="{% url 'index' %}?search_type=links&q=content.consumerfinance.gov"
-      >
-        Search "content.consumerfinance.gov"
-      </a>
-    </li>
-    <li class="m-list__item">
-      You want to find and remediate broken links.
-      <a href="{% url 'index' %}?search_type=links&q=none">Search "none"</a>
-    </li>
-    <li class="m-list__item">
-      You're looking for incorrectly formatted document links.
-      <a
-        href="{% url 'index' %}?search_type=links&q={{ 'www.consumerfinance.gov/documents' | urlencode }}"
-      >
-        Search "www.consumerfinance.gov/documents"
-      </a>
-    </li>
-  </ul>
-</div>
-
-<div class="block block--sub">
-  <h2>Full text</h2>
-  <p>
-    Find all instances of a term or exact phrase in the full text of the
-    &lt;body&gt; of a page, excluding the header and footer.
-  </p>
-  <h3>Examples</h3>
-  <ul class="m-list">
-    <li class="m-list__item">
-      You're looking for specific phrasing or language that might need to be
-      updated because of a policy change.
-      <a
-        href="{% url 'index' %}?search_type=text&q={{ 'medical debt' | urlencode }}"
-      >
-        Search "medical debt"
-      </a>
-    </li>
-  </ul>
-</div>
-
-<div class="block block--sub">
-  <h2>HTML</h2>
-  <p>
-    Find all instances of a string in the HTML of the &lt;body&gt; of a cf.gov
-    page, excluding the header and footer.
-  </p>
-  <h3>Examples</h3>
-  <ul class="m-list">
-    <li class="m-list__item">
-      You want to find and remediate manually-added line breaks.
-      <a href="{% url 'index' %}?search_type=html&q={{ '<br>' | urlencode }}">
-        Search "&lt;br&gt;"
-      </a>
-    </li>
-    <li class="m-list__item">
-      You want to find pages that include a specific image filename.
-      <a href="{% url 'index' %}?search_type=html&q=consumer_tools_hero">
-        Search "consumer_tools_hero"
-      </a>
-    </li>
-    <li class="m-list__item">
-      You want to find pages encoded in Traditional Chinese.
-      <a href="{% url 'index' %}?search_type=html&q=html+lang=%22zh-Hant%22">
-        Search "html lang="zh-Hant""
-      </a>
-    </li>
-    <li class="m-list__item">
-      You want to find pages containing one of our
+    <p>
+      This tool stores a nightly snapshot of consumerfinance.gov web page data
+      that you can search for all sorts of useful things. Common search examples
+      are below. You can also
+      <a href="#data-about">learn more about the data</a>.
+    </p>
+    <p>
+      View results in the browser, or export them as a CSV. For those less handy
+      with Excel, it may be useful to
       <a
         class="a-link a-link__icon"
-        href="https://cfpb.github.io/design-system/foundation/iconography"
+        href="{% static 'query-string-filtering.docx' %}"
       >
-        <span class="a-link__text">named icons</span>
-        {% include "external-link.svg" %}</a
-      >.
-      <a href="{% url 'index' %}?search_type=html&q=cf-icon-svg--college">
-        Search "cf-icon-svg--college"
+        <span class="a-link__text"
+          >learn how to filter out results with query strings</span
+        >
+        {% include "download.svg" %}.
       </a>
-    </li>
-  </ul>
-</div>
+    </p>
+  </div>
 
-<div class="block">
-  <div class="o-well">
-    <div id="data-about" class="lead-paragraph">About the data</div>
-    <p>
-      This index contains web page data saved from the www.consumerfinance.gov
-      domain.
-    </p>
-    <p>
-      The index is built using an iterative process that "crawls" every page of
-      the website, starting at the home page. A web crawler starts on that page,
-      then follows every link on that page, then follows every link on those
-      pages, and so on. If a link leaves the www.consumerfinance.gov domain, it
-      is ignored. In this way, the crawler covers every page on the website that
-      is linked from any other page.
-    </p>
-    <p>The data <strong>excludes</strong>:</p>
+  <div class="block block--sub">
+    <h2>Title</h2>
+    <p>Find all instances of a string in the title of a cf.gov page.</p>
+    <h3>Examples</h3>
     <ul class="m-list">
       <li class="m-list__item">
-        Pages on other subdomains, like files.consumerfinance.gov, although it
-        does track links to those pages.
-      </li>
-      <li class="m-list__item">
-        Pages with query parameters, with the exception of the ?page= query
-        parameter. So, "/about-us/blog/?page=1" is included, but
-        "/about-us/blog/?title=&topics=financial-education" is not.
+        You want a list of all pages with the word "Chopra" in the title.
+        <a href="{% url 'index' %}?search_type=title&q=Chopra"
+          >Search "Chopra"</a
+        >
       </li>
     </ul>
   </div>
-</div>
+
+  <div class="block block--sub">
+    <h2>URL</h2>
+    <p>Find all instances of a string in the URL of a cf.gov page.</p>
+    <h3>Examples</h3>
+    <ul class="m-list">
+      <li class="m-list__item">
+        Your stakeholder wants a list of all the pages in a given site section.
+        <a
+          href="{% url 'index' %}?search_type=links&q={{ '/about-us/the-bureau/bureau-structure/' | urlencode }}"
+        >
+          Search "/about-us/the-bureau/bureau-structure/"
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="block block--sub">
+    <h2>Components</h2>
+    <p>
+      Search by
+      <a href="{% url 'components' %}">class names</a>
+      of our
+      <a
+        class="a-link a-link__icon"
+        href="https://cfpb.github.io/design-system/"
+      >
+        <span class="a-link__text">Design System</span>
+        {% include "external-link.svg" %}</a
+      >
+      components and patterns. Partial searches also work: searching for
+      "notification" will return pages containing "m-notification",
+      "m-notification__borderless", etc.
+    </p>
+    <h3>Examples</h3>
+    <ul class="m-list">
+      <li class="m-list__item">
+        You're doing an audit of all occurrences of the notification pattern.
+        <a href="{% url 'index' %}?search_type=components&q=m-notification">
+          Search "m-notification"
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="block block--sub">
+    <h2>Links</h2>
+    <p>
+      Find all instances of a string in the URLs of links listed on a cf.gov
+      page, excluding the header and footer.
+    </p>
+    <h3>Examples</h3>
+    <ul class="m-list">
+      <li class="m-list__item">
+        You're looking for all instances of external links to the FTC.
+        <a href="{% url 'index' %}?search_type=links&q=FTC">Search "FTC"</a>
+      </li>
+      <li class="m-list__item">
+        You want to find and remediate accidental links to the content server.
+        <a
+          href="{% url 'index' %}?search_type=links&q=content.consumerfinance.gov"
+        >
+          Search "content.consumerfinance.gov"
+        </a>
+      </li>
+      <li class="m-list__item">
+        You want to find and remediate broken links.
+        <a href="{% url 'index' %}?search_type=links&q=none">Search "none"</a>
+      </li>
+      <li class="m-list__item">
+        You're looking for incorrectly formatted document links.
+        <a
+          href="{% url 'index' %}?search_type=links&q={{ 'www.consumerfinance.gov/documents' | urlencode }}"
+        >
+          Search "www.consumerfinance.gov/documents"
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="block block--sub">
+    <h2>Full text</h2>
+    <p>
+      Find all instances of a term or exact phrase in the full text of the
+      &lt;body&gt; of a page, excluding the header and footer.
+    </p>
+    <h3>Examples</h3>
+    <ul class="m-list">
+      <li class="m-list__item">
+        You're looking for specific phrasing or language that might need to be
+        updated because of a policy change.
+        <a
+          href="{% url 'index' %}?search_type=text&q={{ 'medical debt' | urlencode }}"
+        >
+          Search "medical debt"
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="block block--sub">
+    <h2>HTML</h2>
+    <p>
+      Find all instances of a string in the HTML of the &lt;body&gt; of a cf.gov
+      page, excluding the header and footer.
+    </p>
+    <h3>Examples</h3>
+    <ul class="m-list">
+      <li class="m-list__item">
+        You want to find and remediate manually-added line breaks.
+        <a href="{% url 'index' %}?search_type=html&q={{ '<br>' | urlencode }}">
+          Search "&lt;br&gt;"
+        </a>
+      </li>
+      <li class="m-list__item">
+        You want to find pages that include a specific image filename.
+        <a href="{% url 'index' %}?search_type=html&q=consumer_tools_hero">
+          Search "consumer_tools_hero"
+        </a>
+      </li>
+      <li class="m-list__item">
+        You want to find pages encoded in Traditional Chinese.
+        <a href="{% url 'index' %}?search_type=html&q=html+lang=%22zh-Hant%22">
+          Search "html lang="zh-Hant""
+        </a>
+      </li>
+      <li class="m-list__item">
+        You want to find pages containing one of our
+        <a
+          class="a-link a-link__icon"
+          href="https://cfpb.github.io/design-system/foundation/iconography"
+        >
+          <span class="a-link__text">named icons</span>
+          {% include "external-link.svg" %}</a
+        >.
+        <a href="{% url 'index' %}?search_type=html&q=cf-icon-svg--college">
+          Search "cf-icon-svg--college"
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="block">
+    <div class="o-well">
+      <div id="data-about" class="lead-paragraph">About the data</div>
+      <p>
+        This index contains web page data saved from the www.consumerfinance.gov
+        domain.
+      </p>
+      <p>
+        The index is built using an iterative process that "crawls" every page
+        of the website, starting at the home page. A web crawler starts on that
+        page, then follows every link on that page, then follows every link on
+        those pages, and so on. If a link leaves the www.consumerfinance.gov
+        domain, it is ignored. In this way, the crawler covers every page on the
+        website that is linked from any other page.
+      </p>
+      <p>The data <strong>excludes</strong>:</p>
+      <ul class="m-list">
+        <li class="m-list__item">
+          Pages on other subdomains, like files.consumerfinance.gov, although it
+          does track links to those pages.
+        </li>
+        <li class="m-list__item">
+          Pages with query parameters, with the exception of the ?page= query
+          parameter. So, "/about-us/blog/?page=1" is included, but
+          "/about-us/blog/?title=&topics=financial-education" is not.
+        </li>
+      </ul>
+    </div>
+  </div>
 {% endblock %}

--- a/viewer/templates/viewer/page_detail.html
+++ b/viewer/templates/viewer/page_detail.html
@@ -1,109 +1,108 @@
 {% extends './base.html' %}
 
-<!-- prettier-ignore -->
 {% block breadcrumbs %}
-{% include "viewer/breadcrumbs.html" %}
+  {% include "viewer/breadcrumbs.html" %}
 {% endblock breadcrumbs %}
 
 {% block content %}
-<div class="block block--flush-top block--flush-bottom">
-  <h1>{{ title }}</h1>
-</div>
+  <div class="block block--flush-top block--flush-bottom">
+    <h1>{{ title }}</h1>
+  </div>
 
-<div class="block block--flush-top">
-  <p class="u-nowrap"><a href="{{ url }}">{{ url }}</a></p>
-  <p>(last crawled {{ timestamp }})</p>
-</div>
+  <div class="block block--flush-top">
+    <p class="u-nowrap"><a href="{{ url }}">{{ url }}</a></p>
+    <p>(last crawled {{ timestamp }})</p>
+  </div>
 
-<div class="block block--sub">
-  <div
-    class="o-expandable o-expandable--background o-expandable--border {% if request.query_params.search_type == 'links' %}o-expandable--onload-open{% endif %}"
-  >
-    <button class="o-expandable__header" title="Expand content">
-      <h3 class="h4 o-expandable__label">Links</h3>
-      <span class="o-expandable__cues">
-        <span class="o-expandable__cue-open" role="img" aria-label="Show">
-          {% include "plus-round.svg" %}
+  <div class="block block--sub">
+    <div
+      class="o-expandable o-expandable--background o-expandable--border {% if request.query_params.search_type == 'links' %}o-expandable--onload-open{% endif %}"
+    >
+      <button class="o-expandable__header" title="Expand content">
+        <h3 class="h4 o-expandable__label">Links</h3>
+        <span class="o-expandable__cues">
+          <span class="o-expandable__cue-open" role="img" aria-label="Show">
+            {% include "plus-round.svg" %}
+          </span>
+          <span class="o-expandable__cue-close" role="img" aria-label="Hide">
+            {% include "minus-round.svg" %}
+          </span>
         </span>
-        <span class="o-expandable__cue-close" role="img" aria-label="Hide">
-          {% include "minus-round.svg" %}
-        </span>
-      </span>
-    </button>
-    <div class="o-expandable__content">
-      <ul class="m-list">
-        {% for link in links %}
-        <li class="m-list__item u-truncate">{{ link }}</li>
-        {% endfor %}
-      </ul>
+      </button>
+      <div class="o-expandable__content">
+        <ul class="m-list">
+          {% for link in links %}
+            <li class="m-list__item u-truncate">{{ link }}</li>
+          {% endfor %}
+        </ul>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="block block--sub">
-  <div
-    class="o-expandable o-expandable--background o-expandable--border {% if request.query_params.search_type == 'components' %}o-expandable--onload-open{% endif %}"
-  >
-    <button class="o-expandable__header" title="Expand content">
-      <h3 class="h4 o-expandable__label">Components</h3>
-      <span class="o-expandable__cues">
-        <span class="o-expandable__cue-open" role="img" aria-label="Show">
-          {% include "plus-round.svg" %}
+  <div class="block block--sub">
+    <div
+      class="o-expandable o-expandable--background o-expandable--border {% if request.query_params.search_type == 'components' %}o-expandable--onload-open{% endif %}"
+    >
+      <button class="o-expandable__header" title="Expand content">
+        <h3 class="h4 o-expandable__label">Components</h3>
+        <span class="o-expandable__cues">
+          <span class="o-expandable__cue-open" role="img" aria-label="Show">
+            {% include "plus-round.svg" %}
+          </span>
+          <span class="o-expandable__cue-close" role="img" aria-label="Hide">
+            {% include "minus-round.svg" %}
+          </span>
         </span>
-        <span class="o-expandable__cue-close" role="img" aria-label="Hide">
-          {% include "minus-round.svg" %}
-        </span>
-      </span>
-    </button>
-    <div class="o-expandable__content">
-      <ul class="m-list">
-        {% for component in components %}
-        <li class="m-list__item">{{ component }}</li>
-        {% endfor %}
-      </ul>
+      </button>
+      <div class="o-expandable__content">
+        <ul class="m-list">
+          {% for component in components %}
+            <li class="m-list__item">{{ component }}</li>
+          {% endfor %}
+        </ul>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="block block--sub">
-  <div
-    class="o-expandable o-expandable--background o-expandable--border {% if request.query_params.search_type == 'text' %}o-expandable--onload-open{% endif %}"
-  >
-    <button class="o-expandable__header" title="Expand content">
-      <h3 class="h4 o-expandable__label">Text</h3>
-      <span class="o-expandable__cues">
-        <span class="o-expandable__cue-open" role="img" aria-label="Show">
-          {% include "plus-round.svg" %}
+  <div class="block block--sub">
+    <div
+      class="o-expandable o-expandable--background o-expandable--border {% if request.query_params.search_type == 'text' %}o-expandable--onload-open{% endif %}"
+    >
+      <button class="o-expandable__header" title="Expand content">
+        <h3 class="h4 o-expandable__label">Text</h3>
+        <span class="o-expandable__cues">
+          <span class="o-expandable__cue-open" role="img" aria-label="Show">
+            {% include "plus-round.svg" %}
+          </span>
+          <span class="o-expandable__cue-close" role="img" aria-label="Hide">
+            {% include "minus-round.svg" %}
+          </span>
         </span>
-        <span class="o-expandable__cue-close" role="img" aria-label="Hide">
-          {% include "minus-round.svg" %}
-        </span>
-      </span>
-    </button>
-    <div class="o-expandable__content">
-      <pre>{{ text }}</pre>
+      </button>
+      <div class="o-expandable__content">
+        <pre>{{ text }}</pre>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="block block--sub">
-  <div
-    class="o-expandable o-expandable--background o-expandable--border {% if request.query_params.search_type == 'html' %}o-expandable--onload-open{% endif %}"
-  >
-    <button class="o-expandable__header" title="Expand content">
-      <h3 class="h4 o-expandable__label">Raw HTML</h3>
-      <span class="o-expandable__cues">
-        <span class="o-expandable__cue-open" role="img" aria-label="Show">
-          {% include "plus-round.svg" %}
+  <div class="block block--sub">
+    <div
+      class="o-expandable o-expandable--background o-expandable--border {% if request.query_params.search_type == 'html' %}o-expandable--onload-open{% endif %}"
+    >
+      <button class="o-expandable__header" title="Expand content">
+        <h3 class="h4 o-expandable__label">Raw HTML</h3>
+        <span class="o-expandable__cues">
+          <span class="o-expandable__cue-open" role="img" aria-label="Show">
+            {% include "plus-round.svg" %}
+          </span>
+          <span class="o-expandable__cue-close" role="img" aria-label="Hide">
+            {% include "minus-round.svg" %}
+          </span>
         </span>
-        <span class="o-expandable__cue-close" role="img" aria-label="Hide">
-          {% include "minus-round.svg" %}
-        </span>
-      </span>
-    </button>
-    <div class="o-expandable__content">
-      <pre><code class="language-html">{{ html }}</code></pre>
+      </button>
+      <div class="o-expandable__content">
+        <pre><code class="language-html">{{ html }}</code></pre>
+      </div>
     </div>
   </div>
-</div>
 {% endblock content %}

--- a/viewer/templates/viewer/page_list.html
+++ b/viewer/templates/viewer/page_list.html
@@ -63,19 +63,12 @@
 <div class="block block--sub">
   <nav class="m-pagination" role="navigation" aria-label="Pagination">
     <a
-      {%
-      if
-      previous
-      %}
+      {% if previous %}
       class="a-btn m-pagination__btn-prev"
       href="{{ previous }}"
-      {%
-      else
-      %}
+      {% else %}
       class="a-btn a-btn--disabled m-pagination__btn-prev"
-      {%
-      endif
-      %}
+      {% endif %}
     >
       <span class="a-btn__icon a-btn__icon--on-left">
         {% include 'left.svg' %}
@@ -83,19 +76,12 @@
       Previous
     </a>
     <a
-      {%
-      if
-      next
-      %}
+      {% if next %}
       class="a-btn m-pagination__btn-next"
       href="{{ next }}"
-      {%
-      else
-      %}
+      {% else %}
       class="a-btn a-btn--disabled m-pagination__btn-next"
-      {%
-      endif
-      %}
+      {% endif %}
     >
       Next
       <span class="a-btn__icon a-btn__icon--on-right">

--- a/viewer/templates/viewer/page_list.html
+++ b/viewer/templates/viewer/page_list.html
@@ -4,7 +4,6 @@
   <div
     class="m-notification m-notification--{% if count %}success{% else %}warning{% endif %} m-notification--visible"
   >
-    <!-- prettier-ignore -->
     {% if count %}
       {% include "approved-round.svg" %}
     {% else %}
@@ -13,24 +12,23 @@
     <div class="m-notification__content">
       <div class="m-notification__message">{% results_summary %}</div>
       {% if count %}
-      <ul class="m-list m-list--links">
-        <li class="m-list__item">
-          <a
-            class="a-link a-link--jump"
-            href="{% url 'index' %}?format=csv{% if request.query_params.search_type %}&search_type={{ request.query_params.search_type | urlencode }}{% endif %}{% if request.query_params.q %}&q={{ request.query_params.q | urlencode }}{% endif %}"
-          >
-            <span class="a-link__text">Download search results</span>
-            {% include "download.svg" %}</a
-          >
-          <span>
-            <!-- prettier-ignore -->
-            {# Use an arbitrary estimate of how big the CSV is likely to be. #}
-            {# Use Django's built-in width ratio tag as a way to multiply. #}
-            {% widthratio count 1 256 as csv_file_size %}
-            (CSV, ~{{ csv_file_size | filesizeformat }})
-          </span>
-        </li>
-      </ul>
+        <ul class="m-list m-list--links">
+          <li class="m-list__item">
+            <a
+              class="a-link a-link--jump"
+              href="{% url 'index' %}?format=csv{% if request.query_params.search_type %}&search_type={{ request.query_params.search_type | urlencode }}{% endif %}{% if request.query_params.q %}&q={{ request.query_params.q | urlencode }}{% endif %}"
+            >
+              <span class="a-link__text">Download search results</span>
+              {% include "download.svg" %}</a
+            >
+            <span>
+              {# Use an arbitrary estimate of how big the CSV is likely to be. #}
+              {# Use Django's built-in width ratio tag as a way to multiply. #}
+              {% widthratio count 1 256 as csv_file_size %}
+              (CSV, ~{{ csv_file_size | filesizeformat }})
+            </span>
+          </li>
+        </ul>
       {% endif %}
     </div>
   </div>
@@ -40,93 +38,94 @@
   <div class="results-list">
     <ul class="m-list">
       {% for page in results %}
-      <li class="results-list__item">
-        <h4>
-          <a class="a-link a-link--icon u-nowrap" href="{{ page.url }}">
-            <span class="a-link__text u-truncate">{{ page.title }}</span>
-            {% include "external-link.svg" %}</a
+        <li class="results-list__item">
+          <h4>
+            <a class="a-link a-link--icon u-nowrap" href="{{ page.url }}">
+              <span class="a-link__text u-truncate">{{ page.title }}</span>
+              {% include "external-link.svg" %}</a
+            >
+          </h4>
+          <div class="u-truncate">{{ page.url }}</div>
+          <a
+            href="{% url 'page' %}?url={{ page.url | urlencode }}{% if request.query_params.search_type %}&search_type={{ request.query_params.search_type | urlencode }}{% endif %}{% if request.query_params.q %}&q={{ request.query_params.q | urlencode }}{% endif %}"
           >
-        </h4>
-        <div class="u-truncate">{{ page.url }}</div>
-        <a
-          href="{% url 'page' %}?url={{ page.url | urlencode }}{% if request.query_params.search_type %}&search_type={{ request.query_params.search_type | urlencode }}{% endif %}{% if request.query_params.q %}&q={{ request.query_params.q | urlencode }}{% endif %}"
-        >
-          Details
-        </a>
-      </li>
+            Details
+          </a>
+        </li>
       {% endfor %}
     </ul>
   </div>
 </div>
 
 {% if previous or next %}
-<div class="block block--sub">
-  <nav class="m-pagination" role="navigation" aria-label="Pagination">
-    <a
-      {% if previous %}
-      class="a-btn m-pagination__btn-prev"
-      href="{{ previous }}"
-      {% else %}
-      class="a-btn a-btn--disabled m-pagination__btn-prev"
-      {% endif %}
-    >
-      <span class="a-btn__icon a-btn__icon--on-left">
-        {% include 'left.svg' %}
-      </span>
-      Previous
-    </a>
-    <a
-      {% if next %}
-      class="a-btn m-pagination__btn-next"
-      href="{{ next }}"
-      {% else %}
-      class="a-btn a-btn--disabled m-pagination__btn-next"
-      {% endif %}
-    >
-      Next
-      <span class="a-btn__icon a-btn__icon--on-right">
-        {% include 'right.svg' %}
-      </span>
-    </a>
-    <form class="m-pagination__form" action="{% url 'index' %}">
-      <label class="m-pagination__label" for="m-pagination__current-page">
-        Page
-        <span class="u-visually-hidden"> {{ page_obj.number }} out </span>
+  <div class="block block--sub">
+    <nav class="m-pagination" role="navigation" aria-label="Pagination">
+      <a
+        {% if previous %}
+          class="a-btn m-pagination__btn-prev" href="{{ previous }}"
+        {% else %}
+          class="a-btn a-btn--disabled m-pagination__btn-prev"
+        {% endif %}
+      >
+        <span class="a-btn__icon a-btn__icon--on-left">
+          {% include 'left.svg' %}
+        </span>
+        Previous
+      </a>
+      <a
+        {% if next %}
+          class="a-btn m-pagination__btn-next" href="{{ next }}"
+        {% else %}
+          class="a-btn a-btn--disabled m-pagination__btn-next"
+        {% endif %}
+      >
+        Next
+        <span class="a-btn__icon a-btn__icon--on-right">
+          {% include 'right.svg' %}
+        </span>
+      </a>
+      <form class="m-pagination__form" action="{% url 'index' %}">
+        <label class="m-pagination__label" for="m-pagination__current-page">
+          Page
+          <span class="u-visually-hidden"> {{ page_obj.number }} out </span>
+          <input
+            class="m-pagination__current-page"
+            id="m-pagination__current-page-default"
+            name="page"
+            type="number"
+            min="1"
+            max="{{ num_pages }}"
+            pattern="[0-9]*"
+            inputmode="numeric"
+            value="{{ page_number }}"
+          />
+          of {{ num_pages }}
+        </label>
+        <button
+          class="a-btn a-btn--link m-pagination__btn-submit"
+          type="submit"
+        >
+          Go
+        </button>
         <input
-          class="m-pagination__current-page"
-          id="m-pagination__current-page-default"
-          name="page"
-          type="number"
-          min="1"
-          max="{{ num_pages }}"
-          pattern="[0-9]*"
-          inputmode="numeric"
-          value="{{ page_number }}"
+          type="hidden"
+          name="search_type"
+          value="{{ request.query_params.search_type }}"
         />
-        of {{ num_pages }}
-      </label>
-      <button class="a-btn a-btn--link m-pagination__btn-submit" type="submit">
-        Go
-      </button>
-      <input
-        type="hidden"
-        name="search_type"
-        value="{{ request.query_params.search_type }}"
-      />
-      <input type="hidden" name="q" value="{{ request.query_params.q }}" />
-    </form>
-  </nav>
-</div>
+        <input type="hidden" name="q" value="{{ request.query_params.q }}" />
+      </form>
+    </nav>
+  </div>
 {% endif %}
 
 <div class="block block--sub">
   <div class="o-well">
     <div class="h3">Discover more</div>
     {% if crawl_stats.start %}
-    <div class="crawl-date">
-      <span id="last-crawl" class="crawl-date__text">Data last updated:</span>
-      <p>{{ crawl_stats.start | format_datetime }}</p>
-    </div>
+      <div class="crawl-date">
+        <span id="last-crawl" class="crawl-date__text">Data last updated:</span>
+        <p>{{ crawl_stats.start | format_datetime }}</p>
+      </div>
     {% endif %}
     <ul class="m-list">
       <li>

--- a/viewer/templates/viewer/search_form.html
+++ b/viewer/templates/viewer/search_form.html
@@ -40,63 +40,74 @@
 
     <div class="o-form__group search-options">
       <div class="m-form-field m-form-field--radio">
-        <!-- prettier-ignore -->
         <input
           class="a-radio"
           type="radio"
           value="title"
           id="search_type_title"
           name="search_type"
-          {% if request.query_params.search_type is None or request.query_params.search_type == 'title' %} checked{% endif %}
-        >
+          {% if request.query_params.search_type is None or request.query_params.search_type == 'title' %}checked{% endif %}
+        />
         <label class="a-label" for="search_type_title">
           Title
           <span>Search page titles</span>
         </label>
       </div>
       <div class="m-form-field m-form-field--radio">
-        <input class="a-radio" type="radio" value="url" id="search_type_url"
-        name="search_type"{% if request.query_params.search_type == 'url' %}
-        checked{% endif %}>
+        <input
+          class="a-radio"
+          type="radio"
+          value="url"
+          id="search_type_url"
+          name="search_type"
+          {% if request.query_params.search_type == 'url' %}
+            checked
+          {% endif %}
+        />
         <label class="a-label" for="search_type_url">
           URL
           <span>Search page URLs</span>
         </label>
       </div>
       <div class="m-form-field m-form-field--radio">
-        <!-- prettier-ignore -->
         <input
           class="a-radio"
           type="radio"
           value="text"
           id="search_type_text"
           name="search_type"
-          {% if request.query_params.search_type == 'text' %} checked{% endif %}
-        >
+          {% if request.query_params.search_type == 'text' %}checked{% endif %}
+        />
         <label class="a-label" for="search_type_text">
           Full text
           <span>Search page text</span>
         </label>
       </div>
       <div class="m-form-field m-form-field--radio">
-        <input class="a-radio" type="radio" value="links" id="search_type_links"
-        name="search_type"{% if request.query_params.search_type == 'links' %}
-        checked{% endif %}>
+        <input
+          class="a-radio"
+          type="radio"
+          value="links"
+          id="search_type_links"
+          name="search_type"
+          {% if request.query_params.search_type == 'links' %}
+            checked
+          {% endif %}
+        />
         <label class="a-label" for="search_type_links">
           Links
           <span>Search link URLs contained on CF.gov pages</span>
         </label>
       </div>
       <div class="m-form-field m-form-field--radio">
-        <!-- prettier-ignore -->
         <input
           class="a-radio"
           type="radio"
           value="components"
           id="search_type_components"
           name="search_type"
-          {% if request.query_params.search_type == 'components' %} checked{% endif %}
-        >
+          {% if request.query_params.search_type == 'components' %}checked{% endif %}
+        />
         <label class="a-label" for="search_type_components">
           Components
           <span>
@@ -117,15 +128,14 @@
         </label>
       </div>
       <div class="m-form-field m-form-field--radio">
-        <!-- prettier-ignore -->
         <input
           class="a-radio"
           type="radio"
           value="html"
           id="search_type_html"
           name="search_type"
-          {% if request.query_params.search_type == 'html' %} checked{% endif %}
-        >
+          {% if request.query_params.search_type == 'html' %}checked{% endif %}
+        />
         <label class="a-label" for="search_type_html">
           HTML
           <span>Search page HTML</span>

--- a/viewer/templates/viewer/search_results.html
+++ b/viewer/templates/viewer/search_results.html
@@ -1,29 +1,30 @@
-{% extends 'viewer/base.html' %} {% load viewer %} {% block content %}
-<div class="block block--sub">
-  <div class="wrapper">
-    <h1>Consumerfinance.gov web page index</h1>
-    <div class="lead-paragraph">
-      This tool generates and stores a nightly snapshot of CF.gov web page
-      <p>
-        data that you can
-        <a href="{% url 'help' %}">search for all sorts of useful things</a>.
-      </p>
+{% extends 'viewer/base.html' %} {% load viewer %}
+{% block content %}
+  <div class="block block--sub">
+    <div class="wrapper">
+      <h1>Consumerfinance.gov web page index</h1>
+      <div class="lead-paragraph">
+        This tool generates and stores a nightly snapshot of CF.gov web page
+        <p>
+          data that you can
+          <a href="{% url 'help' %}">search for all sorts of useful things</a>.
+        </p>
+      </div>
+      {% if crawl_stats.start %}
+        <div class="crawl-date">
+          <span class="crawl-date__text">Data last updated:</span>
+          <p>
+            <a href="#last-crawl">{{ crawl_stats.start | format_datetime }}</a>
+          </p>
+        </div>
+      {% endif %}
     </div>
-    {% if crawl_stats.start %}
-    <div class="crawl-date">
-      <span class="crawl-date__text">Data last updated:</span>
-      <p><a href="#last-crawl">{{ crawl_stats.start | format_datetime }}</a></p>
-    </div>
-    {% endif %}
   </div>
-</div>
 
-<div class="block block--sub">{% include 'viewer/search_form.html' %}</div>
+  <div class="block block--sub">{% include 'viewer/search_form.html' %}</div>
 
-<div class="block block--sub">{% include 'viewer/page_list.html' %}</div>
+  <div class="block block--sub">{% include 'viewer/page_list.html' %}</div>
 
-<!-- prettier-ignore -->
-{% block content_main %}
-{% endblock content_main %}
-
+  {% block content_main %}
+  {% endblock content_main %}
 {% endblock content %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,10 +631,15 @@ postcss@^8.4.39:
     picocolors "^1.0.1"
     source-map-js "^1.2.0"
 
-prettier@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier-plugin-jinja-template@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-jinja-template/-/prettier-plugin-jinja-template-1.4.1.tgz#79ecf70684f571b6166da47ee2dac644e5190277"
+  integrity sha512-YHDa/f9BpEDIYIPKsnmoKQudWszXBPaVifjR7X+W2n/uAzWLXV/j9FEvua3np7gkzSEOFyapJQrCS4YhhbhbdA==
+
+prettier@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR includes some fixups for #96, mainly a fix for broken pagination introduced in that PR. It also bumps Prettier to its latest version 3.3.3 and adds [prettier-plugin-jinja-template](https://github.com/davidodenwald/prettier-plugin-jinja-template) to more sensibly handle Jinja templates without having to use `<!-- prettier-ignore -->` throughout.