### PR TITLE
Wrap long page titles

### DIFF
--- a/viewer/templates/viewer/page_list.html
+++ b/viewer/templates/viewer/page_list.html
@@ -40,8 +40,8 @@
       {% for page in results %}
         <li class="results-list__item">
           <h4>
-            <a class="a-link a-link--icon u-nowrap" href="{{ page.url }}">
-              <span class="a-link__text u-truncate">{{ page.title }}</span>
+            <a class="a-link a-link--icon" href="{{ page.url }}">
+              <span class="a-link__text">{{ page.title }}</span>
               {% include "external-link.svg" %}</a
             >
           </h4>


### PR DESCRIPTION
Instead of truncating longer page titles, wrap them onto as many lines as they need.

See https://github.local/Design-Development/Design-and-Content-Team/issues/507