### PR TITLE
Generalize viewer database configuration

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -160,7 +160,7 @@ ExecStart={SOURCE_ROOT}/venv/bin/gunicorn \\
     --timeout 600 \\
     wsgi
 ExecReload=/bin/kill -s HUP $MAINPID
-Environment=CRAWL_DATABASE={CRAWL_DATABASE}
+Environment=CRAWL_DATABASE=sqlite:///{CRAWL_DATABASE}
 
 [Install]
 WantedBy=multi-user.target

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@ beautifulsoup4==4.12.3
 click==8.1.7
 cssselect==1.2.0
 Django==4.2.15
+dj-database-url==2.2.0
 django-click==2.4.0
 django-debug-toolbar==4.4.6
 django-filter==24.3

--- a/settings.py
+++ b/settings.py
@@ -1,16 +1,9 @@
-"""
-Django settings for viewer project.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/3.2/topics/settings/
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/3.2/ref/settings/
-"""
-
 import os
 import sys
 from pathlib import Path
+
+import dj_database_url
+
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent
@@ -72,28 +65,20 @@ TEMPLATES = [
 WSGI_APPLICATION = "wsgi.application"
 
 
-# Database
-# https://docs.djangoproject.com/en/3.2/ref/settings/#databases
-
-_sample_db_path = str(BASE_DIR / "sample" / "sample.sqlite3")
-_env_db_path = os.getenv("CRAWL_DATABASE")
-
-if _env_db_path and os.path.exists(_env_db_path) and "test" not in sys.argv:
-    CRAWL_DATABASE = _env_db_path
-else:
-    CRAWL_DATABASE = _sample_db_path
-
-_sqlite_db_path = f"file:{CRAWL_DATABASE}?mode=ro"
+# The default database is configured to use a sample SQLite file.
+# Override this by setting DATABASE_URL in the environment.
+# See https://github.com/jazzband/dj-database-url for URL formatting.
+_sample_db_path = f"{BASE_DIR}/sample/sample.sqlite3"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": _sqlite_db_path,
-        "TEST": {
-            "NAME": _sqlite_db_path,
+    "default": dj_database_url.config(
+        default=f"sqlite:///{_sample_db_path}",
+        # Python tests also use the same sample SQLite file.
+        test_options={
+            "NAME": _sample_db_path,
             "MIGRATE": False,
         },
-    },
+    ),
 }
 
 # Internationalization

--- a/viewer/context_processors.py
+++ b/viewer/context_processors.py
@@ -1,6 +1,3 @@
-import os
-
-from django.conf import settings
 from django.db.models import Count, Max, Min
 
 from crawler.models import Page
@@ -24,7 +21,6 @@ def crawl_stats(request=None):
     crawl_stats.update(
         {
             "duration": duration,
-            "database_size": os.path.getsize(settings.CRAWL_DATABASE),
         }
     )
 

--- a/viewer/templates/viewer/page_list.html
+++ b/viewer/templates/viewer/page_list.html
@@ -149,20 +149,6 @@
         and
         <a class="a-link" href="{% url 'redirects' %}?format=api">redirects</a>
       </li>
-      <li class="m-list__item">
-        <a class="a-link a-link__icon" href="{% url 'download-database' %}">
-          <span class="a-link__text">Download the raw SQLite database</span>
-          {% include "download.svg" %}</a
-        >
-        ({{ crawl_stats.database_size | filesizeformat }}) to
-        <a
-          class="a-link a-link__icon"
-          href="https://github.com/cfpb/website-indexer#searching-the-crawl-database"
-        >
-          <span class="a-link__text">query the data locally</span>
-          {% include "external-link.svg" %}</a
-        >
-      </li>
     </ul>
   </div>
 </div>

--- a/viewer/urls.py
+++ b/viewer/urls.py
@@ -10,10 +10,5 @@ urlpatterns = [
     path("components/", views.ComponentListView.as_view(), name="components"),
     path("errors/", views.ErrorListView.as_view(), name="errors"),
     path("redirects/", views.RedirectListView.as_view(), name="redirects"),
-    path(
-        "download-database/",
-        views.DownloadDatabaseView.as_view(),
-        name="download-database",
-    ),
     path("help/", TemplateView.as_view(template_name="viewer/help.html"), name="help"),
 ]

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -29,11 +29,6 @@ from viewer.serializers import (
 )
 
 
-class DownloadDatabaseView(View):
-    def get(self, request, *args, **kwargs):
-        return FileResponse(open(settings.CRAWL_DATABASE, "rb"))
-
-
 class AlsoRenderHTMLMixin:
     @property
     def renderer_classes(self):


### PR DESCRIPTION
This commit generalizes the database configuration used by the Django viewer application. Instead of assuming a SQLite database file, this commit alters the project settings to use [dj-database-url](https://github.com/jazzband/dj-database-url) instead, which supports various database backends.

The `DATABASE_URL` parameter must now specify a dj-database-url configuration string instead of a SQLite file path.

Because the viewer backend now supports any database, the ability to download the raw SQLite database file has been removed from the frontend. Deployments that use SQLite as the database storage can provide alternate ways of exposing that file if needed.

The crawler application still deliberately writes to a SQLite file; a subsequent PR will consolidate this with the viewer database backend by supporting storage of multiple crawls.

The project README has been rewritten to better document how to run the crawler using both a Python virtual environment or Docker.