### PR TITLE
Fix DATABASE_URL environment variable in fabfile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -160,7 +160,7 @@ ExecStart={SOURCE_ROOT}/venv/bin/gunicorn \\
     --timeout 600 \\
     wsgi
 ExecReload=/bin/kill -s HUP $MAINPID
-Environment=CRAWL_DATABASE=sqlite:///{CRAWL_DATABASE}
+Environment=DATABASE_URL=sqlite:///{CRAWL_DATABASE}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Commit ba4b5d0bff798ea588e022cd1b35c3e4712b068d failed to modify the fabfile to properly set the `DATABASE_URL` environment variable instead of the `CRAWL_DATABASE` variable, now that this project has been migrated to dj-database-url.

This commit fixes that.