### PR TITLE
Add support for Google Tag Manager

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,5 +5,6 @@ htmlcov
 sample
 venv
 viewer/static
+viewer/templates/viewer/gtm
 
 crawler/fixtures/sample.json

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ If the `DATABASE_URL` environment variable is left unset, the
 [sample SQLite database file](#sample-test-data)
 will be used.
 
+### Google Tag Manager
+
+To enable Google Tag Manager on all pages on the viewer application,
+define the `GOOGLE_TAG_ID` environment variable.
+
 ## Development
 
 ### Sample test data

--- a/settings.py
+++ b/settings.py
@@ -151,3 +151,5 @@ LOGGING = {
         },
     },
 }
+
+GOOGLE_TAG_ID = os.getenv("GOOGLE_TAG_ID")

--- a/viewer/templates/viewer/base.html
+++ b/viewer/templates/viewer/base.html
@@ -1,3 +1,4 @@
+{% load gtm %}
 {% load static %}
 
 <!doctype html>
@@ -12,6 +13,7 @@
     <title>
       {% block title %}Consumerfinance.gov web page index{% endblock %}
     </title>
+    {% gtm_head %}
     <link
       rel="icon"
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🪱</text></svg>"
@@ -19,6 +21,7 @@
     <link rel="stylesheet" href="{% static 'css/main.css' %}" />
   </head>
   <body>
+    {% gtm_body %}
     <div class="skip-nav">
       <a class="skip-nav__link" href="#main">Skip to main content</a>
     </div>

--- a/viewer/templates/viewer/gtm/body.html
+++ b/viewer/templates/viewer/gtm/body.html
@@ -1,0 +1,5 @@
+{% if GOOGLE_TAG_ID %}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_ID }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{% endif %}

--- a/viewer/templates/viewer/gtm/head.html
+++ b/viewer/templates/viewer/gtm/head.html
@@ -1,0 +1,5 @@
+{% if GOOGLE_TAG_ID %}
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','{{ GOOGLE_TAG_ID }}');</script>
+<!-- End Google Tag Manager -->
+{% endif %}

--- a/viewer/templatetags/gtm.py
+++ b/viewer/templatetags/gtm.py
@@ -1,0 +1,16 @@
+from django import template
+from django.conf import settings
+
+
+register = template.Library()
+
+
+def add_google_tag_id_to_context(context):
+    context["GOOGLE_TAG_ID"] = getattr(settings, "GOOGLE_TAG_ID", None)
+    return context
+
+
+for tag in ("head", "body"):
+    register.inclusion_tag(
+        f"viewer/gtm/{tag}.html", name=f"gtm_{tag}", takes_context=True
+    )(add_google_tag_id_to_context)

--- a/viewer/tests/test_loaders.py
+++ b/viewer/tests/test_loaders.py
@@ -1,0 +1,7 @@
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase
+
+
+class IgnoreMissingSVGsTemplateLoaderTests(SimpleTestCase):
+    def test_loader_returns_empty_content(self):
+        self.assertEqual(render_to_string("nonexistent.svg"), "")


### PR DESCRIPTION
This PR adds Google Tag Manager tags to all crawler pages if the `GOOGLE_TAG_ID` environment variable is defined. The README has been updated to document this.

See internal https://github.local/Design-Development/Design-and-Content-Team/issues/516.