### PR TITLE
Fix: Always query latest crawl results

### DIFF
--- a/crawler/models.py
+++ b/crawler/models.py
@@ -58,7 +58,7 @@ class LatestCrawlManager(models.Manager):
     def get_queryset(self):
         qs = super().get_queryset()
 
-        latest_crawl = Crawl.objects.filter(status=Crawl.Status.FINISHED).last()
+        latest_crawl = Crawl.objects.filter(status=Crawl.Status.FINISHED).first()
 
         if latest_crawl is None:
             return qs.none()

--- a/crawler/tests/test_models.py
+++ b/crawler/tests/test_models.py
@@ -138,6 +138,22 @@ class PageQuerySetTestsNoPages(TestCase):
     def test_no_crawls_no_pages(self):
         self.assertFalse(Page.objects.exists())
 
+    def test_default_queryset_uses_latest_crawl(self):
+        Crawl.objects.create(status=Crawl.Status.FINISHED, config={})
+        second_crawl = Crawl.objects.create(status=Crawl.Status.FINISHED, config={})
+
+        page = Page.objects.create(
+            crawl=second_crawl,
+            timestamp=timezone.now(),
+            url="https://example.com",
+            title="test",
+            html="<html>",
+            text="text",
+        )
+
+        self.assertEqual(Page.objects.all().count(), 1)
+        self.assertEqual(Page.objects.first(), page)
+
 
 class PageQuerySetTests(TestCase):
     fixtures = ["sample.json"]


### PR DESCRIPTION
The existing logic to query latest crawl results by default has a bug. Instead of returning the latest crawl results, it returns the earliest. This commit fixes that issue and adds a regression unit test.