### PR TITLE
Upgrade Django from 4.2.15 to 4.2.16

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.12.3
 click==8.1.7
 cssselect==1.2.0
-Django==4.2.15
+Django==4.2.16
 dj-database-url==2.2.0
 django-click==2.4.0
 django-debug-toolbar==4.4.6


### PR DESCRIPTION
This change bumps the version of Django from 4.2.15 to 4.2.16. This resolves two security issues:

https://docs.djangoproject.com/en/5.1/releases/4.2.16/