### PR TITLE
Allow configuration from file-based env variables

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@
 
 !crawler/**/*.py
 
+!patch_environ/**/*.py
+
 !requirements
 
 !sample/sample.sqlite3

--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ will be used.
 To enable Google Tag Manager on all pages on the viewer application,
 define the `GOOGLE_TAG_ID` environment variable.
 
+### Using files as an alternative to environment variables
+
+As alternative to configuration via environment variable,
+values may be provided in files instead.
+
+Set the `PATCH_ENVIRON_PATH` environment variable to the location of a directory
+containing files named for environment variables to set,
+each containing the desired value for that variable.
+
+When configured this way,
+the application environment will be populated with those file-based values.
+Values that already exist in the environment will not be overwritten.
+
 ## Development
 
 ### Sample test data

--- a/patch_environ/__init__.py
+++ b/patch_environ/__init__.py
@@ -1,0 +1,22 @@
+import os
+import os.path
+import re
+
+
+ENV_FILENAME_RE = re.compile(r"[A-Z_]+")
+
+
+def patch_environ(path, environ=os.environ):
+    """Patch the environment with file-based values.
+
+    Given a path to a directory containing files named for environment
+    variables, set those variables with the content of the files.
+    Do not overwrite variables already set in the environment.
+    """
+    if not path:
+        return
+
+    for filename in os.listdir(path):
+        if ENV_FILENAME_RE.match(filename):
+            with open(os.path.join(path, filename)) as f:
+                environ.setdefault(filename, f.read())

--- a/patch_environ/tests/test_patch_environ.py
+++ b/patch_environ/tests/test_patch_environ.py
@@ -1,0 +1,50 @@
+import os.path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from patch_environ import patch_environ
+
+
+def make_file(filename, contents):
+    with open(filename, "w") as f:
+        f.write(contents)
+
+
+class PatchEnvironTests(TestCase):
+    def test_pass_none_does_nothing(self):
+        environ = {
+            "FOO": "foo",
+            "BAR": "bar",
+        }
+
+        patch_environ(None, environ)
+
+        self.assertEqual(
+            environ,
+            {
+                "FOO": "foo",
+                "BAR": "bar",
+            },
+        )
+
+    def test_patching(self):
+        environ = {
+            "FOO": "foo",
+            "BAR": "bar",
+        }
+
+        with TemporaryDirectory() as tempdir:
+            make_file(os.path.join(tempdir, "BAR"), "test")
+            make_file(os.path.join(tempdir, "FOO_BAR"), "baz")
+            make_file(os.path.join(tempdir, "ignore_lowercase"), "ignore")
+
+            patch_environ(tempdir, environ)
+
+            self.assertEqual(
+                environ,
+                {
+                    "FOO": "foo",
+                    "BAR": "bar",
+                    "FOO_BAR": "baz",
+                },
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.pytest.ini_options]
 addopts = [
   "--cov=crawler",
+  "--cov=patch_environ",
   "--cov=viewer",
   "--cov-branch",
   "--cov-fail-under=100",

--- a/settings.py
+++ b/settings.py
@@ -1,8 +1,12 @@
 import os
-import sys
 from pathlib import Path
 
 import dj_database_url
+
+from patch_environ import patch_environ
+
+# Optionally patch the environment with file-based variables.
+patch_environ(os.getenv("PATCH_ENVIRON_PATH"))
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.


### PR DESCRIPTION
As an alternative to configuration via environment variable, this commit allows for configuration from files instead. This avoids the need to populate a container environment with secret values directly.

The `PATCH_ENVIRON_PATH` environment variable can be pointed to a directory containing files named for the variables to set, containing the desired values for those variables.

The README has been updated to document this feature.