### PR TITLE
Document searching for broken <a> links

### DIFF
--- a/viewer/templates/viewer/help.html
+++ b/viewer/templates/viewer/help.html
@@ -110,6 +110,10 @@
       <li class="m-list__item">
         You want to find and remediate broken links.
         <a href="{% url 'index' %}?search_type=links&q=none">Search "none"</a>
+        or
+        <a href="{% url 'index' %}?search_type=html&q={{ '<a>' | urlencode }}">
+          search "&lt;a&gt;"
+        </a>
       </li>
       <li class="m-list__item">
         You're looking for incorrectly formatted document links.


### PR DESCRIPTION
This commit documents searching HTML for `<a>` to find broken links.

|Before|After|
|-|-|
|<img width="591" alt="image" src="https://github.com/user-attachments/assets/04d4704d-3d20-4b4a-bbf8-a9057164a9bd">|<img width="593" alt="image" src="https://github.com/user-attachments/assets/05fff0e5-ad92-4fc3-bb83-bd566811d8ed">|