### PR TITLE
Better cleanup of incomplete crawls

### DIFF
--- a/crawler/management/commands/manage_crawls.py
+++ b/crawler/management/commands/manage_crawls.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models import OuterRef, Subquery
 
 import djclick as click
@@ -31,17 +32,28 @@ def delete(crawl_id, dry_run):
 
 @cli.command()
 @click.option(
-    "--keep", type=int, help="Keep this many crawls of each status", default=1
+    "--keep", type=int, help="Keep this many finished and failed crawls", default=1
 )
 @click.option("--dry-run", is_flag=True)
+@transaction.atomic
 def clean(keep, dry_run):
-    crawls_to_keep = (
+    # Delete any in-progress crawls that aren't the most recent.
+    started_delete = Crawl.objects.filter(status=Crawl.Status.STARTED).exclude(
+        pk=Crawl.objects.latest("started").pk
+    )
+
+    # Delete any finished and failed crawls except the number to keep.
+    keep_subquery = (
         Crawl.objects.filter(status=OuterRef("status"))
         .order_by("-started")
         .values("pk")[:keep]
     )
 
-    crawls_to_delete = Crawl.objects.exclude(pk__in=Subquery(crawls_to_keep))
+    completed_delete = Crawl.objects.exclude(status=Crawl.Status.STARTED).exclude(
+        pk__in=Subquery(keep_subquery)
+    )
+
+    crawls_to_delete = started_delete | completed_delete
 
     click.secho(f"Deleting {crawls_to_delete.count()} crawls")
     for crawl in crawls_to_delete:


### PR DESCRIPTION
If a crawl job is interrupted, it won't record a final status of `FAILED` or `FINISHED`, but will be left in `STARTED`. The current invocation of "manage.py manage_crawls clean" won't clean up old `STARTED` crawls. This commit modifies the logic of that command to do so, while still retaining the ability to keep 1 completed `FINISHED` and `FAILED` crawl, respectively. The logic won't delete `STARTED` crawls that are the most recent.

Unit tests have been updated to cover this change.