### PR TITLE
Swap scss import order

### DIFF
--- a/esbuild/scripts.js
+++ b/esbuild/scripts.js
@@ -27,7 +27,7 @@ function scripts(baseConfig) {
           },
           {
             from: [
-              "./node_modules/@cfpb/cfpb-design-system/src/components/cfp-icons/icons/*",
+              "./node_modules/@cfpb/cfpb-design-system/src/components/cfpb-icons/icons/*",
             ],
             to: ["./icons"],
           },

--- a/viewer/static_src/js/main.js
+++ b/viewer/static_src/js/main.js
@@ -1,5 +1,6 @@
-import { Expandable } from "@cfpb/cfpb-design-system/src/index.js";
 export * as MainStyles from "../css/main.scss";
+
+import { Expandable } from "@cfpb/cfpb-design-system/src/index.js";
 
 const docElement = document.documentElement;
 docElement.className = docElement.className.replace(


### PR DESCRIPTION
- The generated CSS is handled via the main JS entrypoint. ESBuild reads `main.js` and when encountering the .scss import, it exports the referenced file as `main.css`. When `Expandable` is imported, it too has associated CSS from the DS. With that import coming first, means that it messes up the order of the generated CSS. Moving the `main.scss` import first fixes that.

- Fix typo in cfpb icons path.