### PR TITLE
Fix manage_crawls clean command with no crawls

### DIFF
--- a/crawler/management/commands/manage_crawls.py
+++ b/crawler/management/commands/manage_crawls.py
@@ -37,6 +37,10 @@ def delete(crawl_id, dry_run):
 @click.option("--dry-run", is_flag=True)
 @transaction.atomic
 def clean(keep, dry_run):
+    # If there are no crawls, there's nothing to do.
+    if not Crawl.objects.exists():
+        return
+
     # Delete any in-progress crawls that aren't the most recent.
     started_delete = Crawl.objects.filter(status=Crawl.Status.STARTED).exclude(
         pk=Crawl.objects.latest("started").pk

--- a/crawler/tests/test_commands.py
+++ b/crawler/tests/test_commands.py
@@ -89,6 +89,11 @@ class ManageCrawlsCommandTests(TestCase):
         self.assertEqual(stdout, f"Deleting {c1}\nDry run, skipping deletion\n")
         self.assertEqual(Crawl.objects.count(), 2)
 
+    def test_clean_no_crawls(self):
+        self.assertFalse(Crawl.objects.exists())
+        self.invoke("clean")
+        self.assertFalse(Crawl.objects.exists())
+
     def test_clean(self):
         c1 = Crawl.objects.create(config={}, status=Crawl.Status.STARTED)
         c2 = Crawl.objects.create(config={}, status=Crawl.Status.STARTED)


### PR DESCRIPTION
This commit fixes a bug with the `manage_crawls clean` management command. Currently if this command is invoked with no crawls in the database, it will fail with an unhandled exception. Running the clean command against an empty database should do nothing and simply exit.