### PR TITLE
Fix: Properly crawl redirected URLs

### DIFF
--- a/crawler/wpull/plugin.py
+++ b/crawler/wpull/plugin.py
@@ -82,10 +82,6 @@ class DatabaseWritingPlugin(WpullPlugin):
 
         request = item_session.url_record
 
-        # Don't request pages more than once.
-        if request.url in self.requested_urls:
-            return False
-
         # Always skip certain URLs.
         if SKIP_URLS and any(skip_url.match(request.url) for skip_url in SKIP_URLS):
             return False


### PR DESCRIPTION
The crawler currently doesn't properly crawl URLs that have been redirected (for example, / -> /complaint/). This commit tries to fix that.