### PR TITLE
Restore DEBUG=True by default

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -19,8 +19,8 @@ BASE_DIR = Path(__file__).resolve().parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-insecure-a94cjadrz=y0o+c75138ro=gn3oq0*by)gs1cs88k$9+taepp("
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+# Default DEBUG to True unless we explicitly disable it.
+DEBUG = os.getenv("DJANGO_DEBUG", "true").lower() != "false"
 
 ALLOWED_HOSTS = []
 


### PR DESCRIPTION
Partially reverts #131. We want to keep `DEBUG=True` by default when running the webserver (for easy static files and nice debug errors), but we still want the ability to disable` DEBUG` mode when crawling.

Add the ability to disable `DEBUG` via the `DJANGO_DEBUG` environment variable. Our nightly crawl is configured in an internal crawler-deploy repo that contains the helm chart, so a related change must be made there as well.