### PR TITLE
Fix Dockerfile warning about JSON arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,4 +89,4 @@ ARG PORT=8000
 EXPOSE $PORT
 ENV PORT=$PORT
 
-CMD python manage.py runserver 0.0.0.0:$PORT
+CMD ["sh", "-c", "python manage.py runserver 0.0.0.0:$PORT"]


### PR DESCRIPTION
Building the Docker image for this project currently generates a warning:

> JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals

This change adjusts the `CMD` statement in the Dockerfile to address this warning.

Fixes #135.