### PR TITLE
Update Django from 4.2.21 to 4.2.23

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.12.3
 click==8.1.7
 cssselect==1.2.0
-Django==4.2.21
+Django==4.2.23
 dj-database-url==2.2.0
 django-click==2.4.0
 django-debug-toolbar==4.4.6


### PR DESCRIPTION
[CVE-2025-48432](https://nvd.nist.gov/vuln/detail/cve-2025-48432) (medium severity) is fixed in 4.2.22, [released 6/4/25](https://docs.djangoproject.com/en/5.2/releases/4.2.22/).

There's also a 4.2.23 version, [released 6/10/25](https://docs.djangoproject.com/en/5.2/releases/4.2.23/), so we can upgrade to that as well.