### PR TITLE
Push Docker images to GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,22 +1,23 @@
-name: Test Docker build
+name: Build Docker image and push to GHCR
 
-on: [pull_request]
-
-env:
-  TEST_TAG: cfpb/website-indexer:test
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+    
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build a test image
-        uses: docker/build-push-action@v6
+      - uses: actions/checkout@v4
+      - uses: cfpb/actions/docker-build-push@5b3ff0ebe0ac88a69752a6e0fff1b73a2f6ebcf9
         with:
-          load: true
-          tags: ${{ env.TEST_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Test the image
-        run: docker run --rm ${{ env.TEST_TAG }} python manage.py check
+          image-name: website-indexer
+          token: ${{ secrets.GITHUB_TOKEN }}
+          test-command: docker run --rm $IMAGE python manage.py check


### PR DESCRIPTION
Use [cfpb/actions/docker-build-push](https://github.com/cfpb/actions) to build the Docker image and push to GHCR on all PRs and commits to main.